### PR TITLE
fix: use typing_extensions.TypedDict for Pydantic v2 compat on Python…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-homelab"
-version = "1.3.0"
+version = "1.3.1"
 description = "MCP server that exposes homelab infrastructure tools to AI assistants"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tools/proxmox.py
+++ b/tools/proxmox.py
@@ -6,7 +6,8 @@ All functions use ProxmoxClient for transport — no direct httpx usage here.
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict
+from typing import Literal
+from typing_extensions import TypedDict
 
 from core.config import get_proxmox_config, proxmox_configured
 from core.proxmox_api import ProxmoxClient


### PR DESCRIPTION
… <3.12

proxmox.py imported TypedDict from typing, which Pydantic v2 rejects on Python <3.12. Switched to typing_extensions.TypedDict (matching nodes.py). Bump version to 1.3.1.