### PR TITLE
Remove start-mcp.cmd with hardcoded local paths

### DIFF
--- a/start-mcp.cmd
+++ b/start-mcp.cmd
@@ -1,2 +1,0 @@
-@echo off
-"C:\Users\austi\Desktop\Python Projects\mcp-homelab\.venv\Scripts\python.exe" "C:\Users\austi\Desktop\Python Projects\mcp-homelab\server.py"


### PR DESCRIPTION
Obsolete convenience script — Claude Desktop and VS Code spawn the server directly via setup client config. mcp-homelab serve covers manual launches.