### PR TITLE
feat: HTTP transport with static bearer token auth (Phase 1)

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -1,0 +1,31 @@
+"""Static bearer-token verifier for HTTP transport."""
+from __future__ import annotations
+
+import hmac
+import logging
+
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+
+
+logger = logging.getLogger(__name__)
+
+
+class StaticBearerVerifier(TokenVerifier):
+    """Verify bearer tokens against a static secret from the environment.
+
+    Uses hmac.compare_digest to prevent timing attacks.
+    """
+
+    def __init__(self, expected_token: str) -> None:
+        self._expected = expected_token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if hmac.compare_digest(token, self._expected):
+            return AccessToken(
+                token=token,
+                client_id="mcp-client",
+                scopes=["*"],
+                expires_at=None,
+            )
+        logger.warning("Bearer token authentication failed")
+        return None

--- a/core/config.py
+++ b/core/config.py
@@ -49,10 +49,17 @@ class OPNsenseConfig(BaseModel):
     verify_ssl: bool = False
 
 
+class ServerConfig(BaseModel):
+    transport: Literal["stdio", "http"] = "stdio"
+    host: str = "127.0.0.1"
+    port: int = 8000
+
+
 class AppConfig(BaseModel):
     hosts: dict[str, HostConfig] = Field(default_factory=dict)
     proxmox: ProxmoxConfig | None = None
     opnsense: OPNsenseConfig | None = None
+    server: ServerConfig = Field(default_factory=ServerConfig)
 
     @model_validator(mode="before")
     @classmethod
@@ -132,6 +139,13 @@ def validate_env() -> None:
         for var in ("OPNSENSE_API_KEY", "OPNSENSE_API_SECRET"):
             if not os.environ.get(var):
                 missing.append(var)
+
+    if config.server.transport == "http":
+        bearer_token = os.environ.get("MCP_BEARER_TOKEN", "")
+        if not bearer_token:
+            missing.append("MCP_BEARER_TOKEN")
+        elif len(bearer_token) < 32:
+            missing.append("MCP_BEARER_TOKEN (must be at least 32 characters)")
 
     if missing:
         raise EnvironmentError(

--- a/server.py
+++ b/server.py
@@ -219,7 +219,36 @@ async def list_context_files() -> dict:
 
 
 if __name__ == "__main__":
-    from core.config import load_env, validate_env
+    from core.config import load_config, load_env, validate_env
+
     load_env()
     validate_env()
-    mcp.run()
+
+    config = load_config()
+    if config.server.transport == "http":
+        from pydantic import AnyHttpUrl
+
+        from mcp.server.auth.settings import AuthSettings
+
+        from core.auth import StaticBearerVerifier
+
+        token = os.environ["MCP_BEARER_TOKEN"]
+        mcp.settings.host = config.server.host
+        mcp.settings.port = config.server.port
+        # AuthSettings URLs are required by the MCP SDK's OAuth metadata model
+        # but unused for static bearer-token auth. In production, deploy behind
+        # a TLS-terminating reverse proxy (Caddy/nginx) and update these to
+        # reflect the actual HTTPS URL clients connect to.
+        mcp.settings.auth = AuthSettings(
+            issuer_url=AnyHttpUrl(f"http://{config.server.host}:{config.server.port}"),
+            resource_server_url=AnyHttpUrl(
+                f"http://{config.server.host}:{config.server.port}"
+            ),
+        )
+        # NOTE: _token_verifier is a private FastMCP attribute. The integration
+        # test in test_auth.py verifies auth is enforced end-to-end, so any
+        # breakage from SDK updates will be caught immediately.
+        mcp._token_verifier = StaticBearerVerifier(token)
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,177 @@
+"""Unit tests for HTTP auth and server transport configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.fastmcp import FastMCP
+from pydantic import AnyHttpUrl
+from pydantic import ValidationError
+from ruamel.yaml import YAML
+from starlette.applications import Starlette
+
+from core.auth import StaticBearerVerifier
+from core.config import ServerConfig, validate_env
+
+
+class TestStaticBearerVerifier:
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_access_token(self) -> None:
+        verifier = StaticBearerVerifier("a" * 40)
+
+        result = await verifier.verify_token("a" * 40)
+
+        assert result is not None
+        assert result.token == "a" * 40
+        assert result.client_id == "mcp-client"
+        assert result.scopes == ["*"]
+        assert result.expires_at is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_returns_none(self) -> None:
+        verifier = StaticBearerVerifier("a" * 40)
+
+        result = await verifier.verify_token("b" * 40)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_token_returns_none(self) -> None:
+        verifier = StaticBearerVerifier("a" * 40)
+
+        result = await verifier.verify_token("")
+
+        assert result is None
+
+
+class TestServerConfig:
+    def test_defaults(self) -> None:
+        config = ServerConfig()
+
+        assert config.transport == "stdio"
+        assert config.host == "127.0.0.1"
+        assert config.port == 8000
+
+    def test_http_config(self) -> None:
+        config = ServerConfig(transport="http")
+
+        assert config.transport == "http"
+
+    def test_invalid_transport_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ServerConfig(transport="websocket")  # type: ignore[arg-type]
+
+
+class TestValidateEnvHttpTransport:
+    @staticmethod
+    def _write_http_only_config(config_dir: Path) -> None:
+        yaml = YAML()
+        config_path = config_dir / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "server": {
+                        "transport": "http",
+                        "host": "127.0.0.1",
+                        "port": 8000,
+                    },
+                    "hosts": {
+                        "gamehost": {
+                            "hostname": "gamehost",
+                            "ip": "10.0.0.10",
+                        }
+                    },
+                },
+                handle,
+            )
+
+    def test_validate_env_requires_bearer_token_for_http(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._write_http_only_config(tmp_path)
+        monkeypatch.setenv("MCP_HOMELAB_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+
+        with pytest.raises(EnvironmentError, match="MCP_BEARER_TOKEN"):
+            validate_env()
+
+    def test_validate_env_requires_min_token_length(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._write_http_only_config(tmp_path)
+        monkeypatch.setenv("MCP_HOMELAB_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("MCP_BEARER_TOKEN", "short-token")
+
+        with pytest.raises(EnvironmentError, match="at least 32 characters"):
+            validate_env()
+
+    def test_validate_env_accepts_valid_http_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._write_http_only_config(tmp_path)
+        monkeypatch.setenv("MCP_HOMELAB_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("MCP_BEARER_TOKEN", "a" * 32)
+
+        validate_env()
+
+
+class TestAuthEnforcement:
+    @staticmethod
+    def _build_asgi_app(expected_token: str) -> tuple[Starlette, str]:
+        mcp = FastMCP("auth-test")
+
+        @mcp.tool()
+        async def ping() -> dict[str, str]:
+            return {"status": "ok"}
+
+        mcp.settings.auth = AuthSettings(
+            issuer_url=AnyHttpUrl("http://127.0.0.1:8000"),
+            resource_server_url=AnyHttpUrl("http://127.0.0.1:8000"),
+        )
+        mcp._token_verifier = StaticBearerVerifier(expected_token)
+        return mcp.streamable_http_app(), mcp.settings.streamable_http_path
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_requires_valid_bearer_token(self) -> None:
+        expected_token = "a" * 40
+        app, endpoint = self._build_asgi_app(expected_token)
+
+        headers = {
+            "accept": "application/json, text/event-stream",
+            "content-type": "application/json",
+        }
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "0.0.1"}},
+        }
+
+        async with app.router.lifespan_context(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                no_auth = await client.post(endpoint, headers=headers, json=payload)
+                assert no_auth.status_code == 401
+
+                wrong_auth = await client.post(
+                    endpoint,
+                    headers={**headers, "authorization": "Bearer wrong-token"},
+                    json=payload,
+                )
+                assert wrong_auth.status_code == 401
+
+                valid_auth = await client.post(
+                    endpoint,
+                    headers={**headers, "authorization": f"Bearer {expected_token}"},
+                    json=payload,
+                )
+                assert valid_auth.status_code != 401


### PR DESCRIPTION
## Summary

Adds optional HTTP transport to mcp-homelab, enabling remote access via MCP's Streamable HTTP protocol with static bearer token authentication. Designed for deployment behind WireGuard VPN.

### What changed

- **\core/auth.py\** — \StaticBearerVerifier\ implementing MCP SDK's \TokenVerifier\ protocol (\hmac.compare_digest\ for timing-attack resistance)
- **\core/config.py\** — \ServerConfig\ model (\	ransport\, \host\, \port\), added to \AppConfig\. \alidate_env()\ requires \MCP_BEARER_TOKEN\ (32+ chars) when transport=http
- **\server.py\** — Transport selection in \__main__\ block: wires \AuthSettings\ + \StaticBearerVerifier\ when http, runs \streamable-http\ transport
- **\config.yaml\** — \server:\ section with stdio default, commented HTTP hints (recommends WireGuard interface IP)
- **\	ests/unit/test_auth.py\** — Unit tests for verifier + config validation, plus integration test proving unauthenticated requests get 401

### Security review findings addressed
- Integration test proves unauthenticated HTTP requests return 401 (blocker resolved)
- TLS guidance documented in code comments (blocker resolved)
- Config recommends WireGuard interface IP over \