### PR TITLE
feat: Cloudflare Tunnel + OAuth deploy automation

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,12 +1,13 @@
 # Deployment
 
-Automated deployment of mcp-homelab to an LXC container with Cloudflare Tunnel for HTTPS.
+Automated deployment of mcp-homelab to a **Debian/Ubuntu** LXC container with Cloudflare Tunnel for HTTPS. The target must use `apt` and `systemd`.
 
 ## Prerequisites
 
 | Requirement                 | Detail                                                                                                                    |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | **Root SSH access**         | Root SSH to the target LXC (key-based, or bootstrapped via `--pve-host` which also installs the deploy key automatically) |
+| **Debian/Ubuntu target**    | The deploy script uses `apt-get` and `systemd` — other distros are not supported                                          |
 | **Cloudflare Tunnel token** | Create a tunnel in Cloudflare Zero Trust dashboard → Tunnels → Create → get the connector token                           |
 | **Public URL**              | The HTTPS hostname you configure in the tunnel's public hostname tab (e.g. `https://mcp.example.com`)                     |
 
@@ -47,7 +48,7 @@ python deploy/deploy.py \
 | `--port`            | No       | `8000`                        | Server listen port                            |
 | `--repo-url`        | No       | GitHub repo                   | Git repository URL                            |
 | `--pve-host`        | No       | —                             | Proxmox VE host for LXC SSH bootstrap         |
-| `--pve-user`        | No       | —                             | SSH user on PVE (required with `--pve-host`)  |
+| `--pve-user`        | No       | —                             | SSH user on PVE — must be `root` or have passwordless sudo for `pct` |
 | `--pve-key`         | No       | —                             | SSH key for PVE (required with `--pve-host`)  |
 | `--vmid`            | No       | `100`                         | LXC container VMID                            |
 

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -177,12 +177,20 @@ def main() -> int:
         print("ERROR: set --cf-tunnel-token or CF_TUNNEL_TOKEN", file=sys.stderr)
         return 2
 
+    if "\n" in cf_tunnel_token or "\r" in cf_tunnel_token:
+        print("ERROR: --cf-tunnel-token must not contain newline characters", file=sys.stderr)
+        return 2
+
     if not public_url:
         print("ERROR: --public-url must not be empty", file=sys.stderr)
         return 2
 
     if not public_url.startswith("https://"):
         print("ERROR: --public-url must start with https://", file=sys.stderr)
+        return 2
+
+    if '"' in public_url or "\n" in public_url or "\r" in public_url:
+        print("ERROR: --public-url contains invalid characters", file=sys.stderr)
         return 2
 
     if bootstrap_enabled:
@@ -224,11 +232,12 @@ def main() -> int:
         )
 
         pub_key_content: str = ssh_key.with_suffix(".pub").read_text(encoding="utf-8").strip()
+        quoted_key: str = shlex.quote(pub_key_content)
         key_install_command: str = (
             f"sudo pct exec {vmid_quoted} -- bash -c "
             + shlex.quote(
                 f"mkdir -p /root/.ssh && chmod 700 /root/.ssh && "
-                f"echo {shlex.quote(pub_key_content)} >> /root/.ssh/authorized_keys && "
+                f"grep -qF {quoted_key} /root/.ssh/authorized_keys 2>/dev/null || echo {quoted_key} >> /root/.ssh/authorized_keys && "
                 f"chmod 600 /root/.ssh/authorized_keys"
             )
         )
@@ -436,7 +445,7 @@ def main() -> int:
             print(cf_result.stderr.strip(), file=sys.stderr)
         elif cf_result.stdout:
             print(cf_result.stdout.strip(), file=sys.stderr)
-        sys.exit(cf_result.returncode)
+        return cf_result.returncode
     _run_ssh_command(
         host,
         ssh_key,


### PR DESCRIPTION
Replace static bearer token deployment with Cloudflare Tunnel HTTPS setup. OAuth mints tokens at runtime so no static secret is needed. Remove --token/MCP_BEARER_TOKEN, add --cf-tunnel-token + --public-url, install cloudflared via apt, register tunnel service. Full README rewrite with prerequisites (passwordless sudo requirement), usage examples, all arguments. 408/408 tests passing.