### PR TITLE
ci: add develop branch to workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        language: [python, actions]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,9 +2,9 @@ name: Secret Scanning
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

CI, gitleaks, and CodeQL workflows only trigger on PRs targeting `master`. The branch protection ruleset requires these checks for `develop` too, so they stay in 'Waiting for status to be reported' forever on develop-targeted PRs (e.g. PR #27).

## Changes

- **ci.yml**: add `develop` to `push` and `pull_request` branch filters
- **gitleaks.yml**: add `develop` to `push` and `pull_request` branch filters
- **codeql.yml**: new custom workflow replacing GitHub default setup, covers both `master` and `develop`

## Post-merge

After merging this PR, disable the CodeQL 'default setup' in repo Settings > Code security > Code scanning to avoid duplicate runs. The custom workflow replaces it.

## Note

This PR itself has the chicken-and-egg problem — checks won't trigger because `develop` doesn't have the fix yet. Admin bypass merge is required.